### PR TITLE
build: java version 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ test {
     testLogging.showStandardStreams = (System.getenv('SHOW_STANDARD_STREAMS') != null)
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = '11'
+targetCompatibility = '11'
 
 compileJava.options.encoding = 'UTF-8'
 
@@ -34,7 +34,7 @@ azurefunctions {
     region = 'westus'
     runtime {
         os = 'windows'
-        javaVersion = '8'
+        javaVersion = '11'
     }
     localDebug = "transport=dt_socket,server=y,suspend=n,address=5005"
 }


### PR DESCRIPTION
Upgrading gradle fails because of wrong Java version:

```
* What went wrong:
Execution failed for task ':compileKotlin'.
> 'compileJava' task (current target is 1.8) and 'compileKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.
  Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```
