### PR TITLE
chore: fix build deprecation warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,14 @@ test {
     testLogging.showStandardStreams = (System.getenv('SHOW_STANDARD_STREAMS') != null)
 }
 
+testing {
+    suites {
+        test {
+            useJUnitJupiter()
+        }
+    }
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)


### PR DESCRIPTION
Fixing the error:

> The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: [https://docs.gradle.org/8.14.3/userguide/upgrading_version_8.html#test_framework_implementation_dependencies](https://fluffy-robot-rrgjg7rrwgh5w9w.github.dev/)